### PR TITLE
Add fixie_url changes to make requests from set IP address

### DIFF
--- a/trackbasket_be/models/krogerservice.py
+++ b/trackbasket_be/models/krogerservice.py
@@ -4,6 +4,11 @@ import requests
 import os
 import json
 
+proxyDict = {
+              "http"  : os.environ.get('FIXIE_URL', ''),
+              "https" : os.environ.get('FIXIE_URL', '')
+            }
+
 class Krogerservice:
 
   @classmethod
@@ -35,7 +40,7 @@ class Krogerservice:
     parameters = {'filter.zipCode.near': zipcode, 'filter.limit':number_results}
     headers = {'Authorization': 'Bearer {}'.format(token)}
     # response1 = requests.get('https://api.kroger.com/supportinfo')
-    response = requests.get('https://api.kroger.com/v1/locations?', params=parameters, headers=headers)
+    response = requests.get('https://api.kroger.com/v1/locations?', params=parameters, headers=headers, proxies=proxyDict)
 #     parsed_response = json.loads(response.text)
     
  #   parsed_response = response.json()
@@ -82,7 +87,7 @@ class Krogerservice:
       return 'error'
 
     headers = {'Authorization': 'Bearer {}'.format(Krogerservice.return_token())}
-    response = requests.get('https://api.kroger.com/v1/products', params=parameters, headers=headers)
+    response = requests.get('https://api.kroger.com/v1/products', params=parameters, headers=headers, proxies=proxyDict)
 
     if response.json()['data'] != []:
       json_items = response.json()['data']


### PR DESCRIPTION
## Who worked on this

- [x] Alexis
- [ ] Maria
- [ ] Ed
- [ ] Cody

## Type of change

- [ ] Style (Non-breaking Style code)
- [ ] Testing (Non-breaking Testing code)
- [ ] Bug fix or refactor (change which fixes an issue)
- [x] New feature (change which adds functionality)

## Summary of the change.

- activated the `fixie` module on the app to make sure that all requests made to the Kroger API come from a fixed IP address (and avoid internal server error caused by banned IP addresses associated with servers on Heroku)

🐞 If it is a bug or issue fix, describe the issue that was fixed.

Some requests to the Kroger API are rejected because the AWS server on which the app is deployed was associated with suspicious activity in the past. 

Using `fixie` allows making sure that all the requests are made from a fixed and safe IP address.

## Checklist:

- [x] My code follows the Turing style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code if necessary
